### PR TITLE
fix: 固定費の標準金額バリデーションを修正

### DIFF
--- a/backend/app/schemas/category.py
+++ b/backend/app/schemas/category.py
@@ -15,14 +15,14 @@ class CategoryBase(BaseModel):
     color: str = Field(default="#808080", pattern=r"^#[0-9A-Fa-f]{6}$")
     is_recurring: bool = Field(default=False)
     frequency: Optional[str] = None  # 'monthly' | 'yearly'
-    default_amount: Optional[int] = Field(None, ge=0)
+    default_amount: Optional[int] = Field(None, ge=1)
 
     @model_validator(mode='after')
     def validate_recurring_fields(self):
         if self.is_recurring:
             if not self.frequency:
                 raise ValueError("固定費の場合は頻度が必要です")
-            if not self.default_amount or self.default_amount <= 1:
+            if not self.default_amount or self.default_amount < 1:
                 raise ValueError("固定費の場合は標準金額が必要です")
         return self
 


### PR DESCRIPTION
## Summary
- 固定費の標準金額の最小値を0から1に変更し、より適切な入力制約を実装

## Test plan
- [x] 標準金額が0の場合にバリデーションエラーが発生することを確認
- [x] 標準金額が1以上の場合に正常に登録できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)